### PR TITLE
Also generate a dynamic function.

### DIFF
--- a/src/com/rpl/defexception/impl.clj
+++ b/src/com/rpl/defexception/impl.clj
@@ -70,4 +70,9 @@
                      (conj args cause)
                      args)))))
 
-
+(defn hyphenate [sym]
+  (-> (name sym)
+      (string/replace #"([A-Z]+)([A-Z][a-z])" "$1-$2")
+      (string/replace #"([a-z\d])([A-Z])" "$1-$2")
+      (string/replace #"_" "-")
+      (string/lower-case)))

--- a/test/com/rpl/defexception_test.clj
+++ b/test/com/rpl/defexception_test.clj
@@ -60,3 +60,8 @@
     (is (= "Message" (.getMessage ex)))
     (is (= {:hello 1} (ex-data ex)))
     (is (= cause (.getCause ex)))))
+
+(deftest rebindable-function
+  (is (thrown? TestException (*test-exception* "blah" {})))
+  (binding [*test-exception* (fn [m data] data)]
+    (is (= {:a 1} (*test-exception* "blah" {:a 1})))))


### PR DESCRIPTION
I find this pattern of using a dynamically bound function to raise exceptions extremely useful as I can often eliminate the need to raise an exception with a bit of context that exists at a higher scope.