### PR TITLE
feat: use class name as the default message

### DIFF
--- a/src/com/rpl/defexception.clj
+++ b/src/com/rpl/defexception.clj
@@ -38,10 +38,10 @@
     `(let [x# (impl/load-or-mk-ex-info-class ~class-name)]
        (import ~(symbol class-name))
        (defn ~(symbol (str "->" t))
-         ([] (impl/make-ex x# nil {} nil))
+         ([] (impl/make-ex x# ~(name t) {} nil))
          ([~'msg-o-data]
           (if (map? ~'msg-o-data)
-            (impl/make-ex x# nil ~'msg-o-data nil)
+            (impl/make-ex x# ~(name t) ~'msg-o-data nil)
             (impl/make-ex x# ~'msg-o-data {} nil)))
          ([~'msg ~'data] (impl/make-ex x# ~'msg ~'data nil))
          ([~'msg ~'data ~'cause] (impl/make-ex x# ~'msg ~'data ~'cause)))

--- a/test/com/rpl/defexception/other_test.clj
+++ b/test/com/rpl/defexception/other_test.clj
@@ -8,13 +8,13 @@
 
 (deftest aot-class-test
   (let [ex (->TestException)]
-    (is (= nil (.getMessage ex)))
+    (is (= "TestException" (.getMessage ex)))
     (is (= {} (ex-data ex))))
   (let [ex (->TestException "Message")]
     (is (= "Message" (.getMessage ex)))
     (is (= {} (ex-data ex))))
   (let [ex (->TestException {:hello 1})]
-    (is (= nil (.getMessage ex)))
+    (is (= "TestException" (.getMessage ex)))
     (is (= {:hello 1} (ex-data ex))))
   (let [ex (->TestException "Message" {:hello 1})]
     (is (= "Message" (.getMessage ex)))
@@ -24,6 +24,3 @@
     (is (= "Message" (.getMessage ex)))
     (is (= {:hello 1} (ex-data ex)))
     (is (= cause (.getCause ex)))))
-
-
-

--- a/test/com/rpl/defexception_test.clj
+++ b/test/com/rpl/defexception_test.clj
@@ -20,13 +20,13 @@
 
 (deftest dynamic-exception-class-const-fn
   (let [ex (->MyException)]
-    (is (= nil (.getMessage ex)))
+    (is (= "MyException" (.getMessage ex)))
     (is (= {} (ex-data ex))))
   (let [ex (->MyException "Message")]
     (is (= "Message" (.getMessage ex)))
     (is (= {} (ex-data ex))))
   (let [ex (->MyException {:hello 1})]
-    (is (= nil (.getMessage ex)))
+    (is (= "MyException" (.getMessage ex)))
     (is (= {:hello 1} (ex-data ex))))
   (let [ex (->MyException "Message" {:hello 1})]
     (is (= "Message" (.getMessage ex)))
@@ -44,13 +44,13 @@
 
 (deftest aot-class-test
   (let [ex (->TestException)]
-    (is (= nil (.getMessage ex)))
+    (is (= "TestException" (.getMessage ex)))
     (is (= {} (ex-data ex))))
   (let [ex (->TestException "Message")]
     (is (= "Message" (.getMessage ex)))
     (is (= {} (ex-data ex))))
   (let [ex (->TestException {:hello 1})]
-    (is (= nil (.getMessage ex)))
+    (is (= "TestException" (.getMessage ex)))
     (is (= {:hello 1} (ex-data ex))))
   (let [ex (->TestException "Message" {:hello 1})]
     (is (= "Message" (.getMessage ex)))


### PR DESCRIPTION
When the exception in constructed without a message, ensure the
ExceptionInfo instance contains identifying information.