### PR TITLE
Fix namespace declaration in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To create your own exception class you can do this:
 
 ```clojure
 (ns foo.bar
- (:require '[com.rpl.defexception :refer [defexception]]))
+ (:require [com.rpl.defexception :refer [defexception]]))
 
 (defexception MyException)
 ```


### PR DESCRIPTION
Removes the quoting of the namespace vector, which is not needed inside (ns ...), and causes the example to fail