### PR TITLE
fix: key constuctor cache by boolean, not instance

### DIFF
--- a/src/clj/com/rpl/defexception/impl.clj
+++ b/src/clj/com/rpl/defexception/impl.clj
@@ -100,6 +100,7 @@
 (def ^:private ex-info-const
   (memoize
    (fn [^Class klass cause?]
+     (assert (boolean? cause?))
      (let [arg-types [String clojure.lang.IPersistentMap]]
        (.getConstructor
         klass
@@ -135,7 +136,7 @@
 (defn make-ex
   "use reflection to instantiate the exception class"
   [^Class klass msg data cause]
-  (let [constr ^java.lang.reflect.Constructor (ex-info-const klass cause)
+  (let [constr ^java.lang.reflect.Constructor (ex-info-const klass (boolean cause))
         args [msg (or data {})]]
     (fix-stack-trace (.newInstance constr
                                    (object-array


### PR DESCRIPTION
The constructor fns generated by defexception use reflection to grab the Java constructors to which they delegate.

We `memoize` this lookup as an optimization. The cache key is now `[exception-class, arity-with-cause?]`.

Previously, we were unintentionally forwarding a nilable instance of a cause rather than a coerced boolean; this could lead to unexpected ballooning of the cache's size.